### PR TITLE
Updating dependencies again

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation "androidx.preference:preference-ktx:1.2.1"
     implementation "androidx.palette:palette-ktx:1.0.0"
     implementation "androidx.annotation:annotation:1.9.1"
-    implementation "androidx.appcompat:appcompat:1.7.0"
+    implementation "androidx.appcompat:appcompat:1.7.1"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.9.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.9.0'
@@ -112,7 +112,7 @@ dependencies {
     implementation "com.jakewharton:butterknife:$butterKnifeVersion"
     kapt "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
 
-    final def mozComponentsVersion = "138.0"
+    final def mozComponentsVersion = "139.0"
 
     // Mozilla compose components
     implementation "org.mozilla.components:compose-awesomebar:$mozComponentsVersion"
@@ -205,9 +205,9 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
 
-    implementation "androidx.compose.ui:ui:1.8.1"
-    implementation "androidx.compose.foundation:foundation:1.8.1"
-    implementation "androidx.compose.material:material:1.8.1"
+    implementation "androidx.compose.ui:ui:1.8.2"
+    implementation "androidx.compose.foundation:foundation:1.8.2"
+    implementation "androidx.compose.material:material:1.8.2"
 
     implementation 'org.jsoup:jsoup:1.14.3'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,18 +1,26 @@
-apply plugin: 'com.android.application'
+import com.android.build.api.variant.FilterConfiguration
 
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'com.google.devtools.ksp'
-apply plugin: 'androidx.navigation.safeargs.kotlin'
-apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
+    id 'androidx.navigation.safeargs.kotlin'
+    id 'org.jetbrains.kotlin.plugin.compose'
+}
 
 
 android {
+
     compileSdkVersion 35
     buildFeatures {
+        buildConfig true
         viewBinding true
         compose true
     }
+
+    namespace 'com.cookiejarapps.android.smartcookieweb'
+
     defaultConfig {
         applicationId "com.cookiejarapps.android.smartcookieweb"
         minSdkVersion 21
@@ -22,6 +30,7 @@ android {
         versionName "29.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
@@ -37,6 +46,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     flavorDimensions "abi"
 
     splits {
@@ -49,29 +59,34 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = '1.5.15'
     }
+
     androidResources {
-        noCompress 'ja'
+        noCompress += 'ja'
     }
+
     lint {
         abortOnError false
     }
-    namespace 'com.cookiejarapps.android.smartcookieweb'
 }
 
-ext.abiCodes = ['arm64-v8a':1, x86:2, x86_64:3]
+def abiBaseMap = [
+        "arm64-v8a": 1,
+        "x86"      : 2,
+        "x86_64"   : 3
+]
 
-import com.android.build.OutputFile
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.each { output ->
+            def abi = output.getFilters()
+                    .find { it.filterType == FilterConfiguration.FilterType.ABI }
+                    ?.identifier
 
-android.applicationVariants.configureEach { variant ->
-
-    variant.outputs.each { output ->
-
-        def baseAbiVersionCode =
-                project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
-
-        if (baseAbiVersionCode != null) {
-            output.versionCodeOverride =
-                    baseAbiVersionCode + variant.versionCode
+            if (abi != null) {
+                def base = abiBaseMap[abi] ?: 0
+                def orig = output.versionCode.get()
+                output.versionCode.set(base * 1000 + orig)
+            }
         }
     }
 }
@@ -127,7 +142,7 @@ dependencies {
     implementation "org.mozilla.components:concept-fetch:$mozComponentsVersion"
     implementation "org.mozilla.components:concept-awesomebar:$mozComponentsVersion"
 
-    // Mozilla components
+    // Mozilla browser components
     implementation "org.mozilla.components:browser-engine-gecko:$mozComponentsVersion"
     implementation "org.mozilla.components:browser-icons:$mozComponentsVersion"
     implementation "org.mozilla.components:browser-domains:$mozComponentsVersion"
@@ -196,7 +211,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 
     // JSON parsing
-    implementation"com.squareup.moshi:moshi:1.11.0"
+    implementation "com.squareup.moshi:moshi:1.11.0"
 
     // OkHTTP
     implementation "com.squareup.okhttp3:okhttp:4.9.3"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'androidx.navigation.safeargs.kotlin'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+
 
 android {
     compileSdkVersion 35
@@ -16,8 +18,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
         // Increment by 4 with each update
-        versionCode 120
-        versionName "28.0"
+        versionCode 124
+        versionName "29.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -83,7 +85,7 @@ dependencies {
 
     // Support libraries
     implementation "androidx.recyclerview:recyclerview:1.4.0"
-    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.core:core-ktx:1.16.0'
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "androidx.drawerlayout:drawerlayout:1.2.0"
     implementation "androidx.preference:preference-ktx:1.2.1"
@@ -91,12 +93,12 @@ dependencies {
     implementation "androidx.annotation:annotation:1.9.1"
     implementation "androidx.appcompat:appcompat:1.7.0"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.8.9'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.8.9'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.9.0'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.9.0'
 
     // Room
-    implementation "androidx.room:room-runtime:2.6.1"
-    ksp "androidx.room:room-compiler:2.6.1"
+    implementation "androidx.room:room-runtime:2.7.1"
+    ksp "androidx.room:room-compiler:2.7.1"
 
     final def daggerVersion = '2.48.1'
     implementation "com.google.dagger:dagger:$daggerVersion"
@@ -110,7 +112,7 @@ dependencies {
     implementation "com.jakewharton:butterknife:$butterKnifeVersion"
     kapt "com.jakewharton:butterknife-compiler:$butterKnifeVersion"
 
-    final def mozComponentsVersion = "137.0"
+    final def mozComponentsVersion = "138.0"
 
     // Mozilla compose components
     implementation "org.mozilla.components:compose-awesomebar:$mozComponentsVersion"
@@ -203,9 +205,9 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxjava:2.2.17'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
 
-    implementation "androidx.compose.ui:ui:1.7.8"
-    implementation "androidx.compose.foundation:foundation:1.7.8"
-    implementation "androidx.compose.material:material:1.7.8"
+    implementation "androidx.compose.ui:ui:1.8.1"
+    implementation "androidx.compose.foundation:foundation:1.8.1"
+    implementation "androidx.compose.material:material:1.8.1"
 
     implementation 'org.jsoup:jsoup:1.14.3'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
         android:resizeableActivity="true"
         android:supportsPictureInPicture="true"
         android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
-        android:exported="true">
+        android:exported="true"
+        tools:targetApi="24">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/BaseBrowserFragment.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/BaseBrowserFragment.kt
@@ -31,7 +31,6 @@ import com.cookiejarapps.android.smartcookieweb.browser.SwipeGestureLayout
 import com.cookiejarapps.android.smartcookieweb.browser.home.HomeFragmentDirections
 import com.cookiejarapps.android.smartcookieweb.components.StoreProvider
 import com.cookiejarapps.android.smartcookieweb.components.toolbar.*
-import com.cookiejarapps.android.smartcookieweb.components.toolbar.ToolbarPosition
 import com.cookiejarapps.android.smartcookieweb.databinding.FragmentBrowserBinding
 import com.cookiejarapps.android.smartcookieweb.downloads.DownloadService
 import com.cookiejarapps.android.smartcookieweb.ext.components
@@ -254,6 +253,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             lifecycleOwner = viewLifecycleOwner
         )
 
+        //TODO: show ssl dialog
+
         toolbarIntegration.set(
             feature = browserToolbarView.toolbarIntegration,
             owner = this,
@@ -453,9 +454,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             view = view
         )
 
-        browserToolbarView.view.display.setOnSiteSecurityClickedListener {
-            activity.showSslDialog()
-        }
 
         expandToolbarOnNavigation(store)
 

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/browser/bookmark/ui/BookmarkAdapter.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/browser/bookmark/ui/BookmarkAdapter.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.withContext
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import java.net.IDN
+import java.util.Locale
+
 
 open class BookmarkAdapter(
     protected val context: Context,
@@ -108,8 +110,8 @@ open class BookmarkAdapter(
 
     fun sortBookmarks(sortType: BookmarkSortType) {
         when (sortType) {
-            BookmarkSortType.A_Z -> items.sortBy { it.title?.toLowerCase() }
-            BookmarkSortType.Z_A -> items.sortByDescending { it.title?.toLowerCase() }
+            BookmarkSortType.A_Z -> items.sortBy { it.title?.lowercase(Locale.getDefault()) }
+            BookmarkSortType.Z_A -> items.sortByDescending { it.title?.lowercase(Locale.getDefault()) }
             BookmarkSortType.MANUAL -> {} // Do nothing, keep the manual order
         }
         notifyDataSetChanged()

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/Components.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/Components.kt
@@ -104,7 +104,7 @@ open class Components(private val applicationContext: Context) {
     }
 
     // Engine Settings
-    val engineSettings by lazy {
+    private val engineSettings by lazy {
         DefaultSettings().apply {
             historyTrackingDelegate = HistoryDelegate(lazyHistoryStorage)
             requestInterceptor = appRequestInterceptor
@@ -308,7 +308,7 @@ open class Components(private val applicationContext: Context) {
     }
 
     val webAppManifestStorage by lazy { ManifestStorage(applicationContext) }
-    val webAppShortcutManager by lazy { WebAppShortcutManager(
+    private val webAppShortcutManager by lazy { WebAppShortcutManager(
             applicationContext,
             client,
             webAppManifestStorage

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
@@ -77,7 +77,7 @@ class BrowserToolbarView(
             true
         }
 
-        //TODO: add security_icon resource
+        // TODO: add security_icon resource
         /*
         val securityIcon = layout.findViewById<ImageView>(R.id.security_icon)
         securityIcon?.setOnClickListener {

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
@@ -77,6 +77,14 @@ class BrowserToolbarView(
             true
         }
 
+        //TODO: add security_icon resource
+        /*
+        val securityIcon = layout.findViewById<ImageView>(R.id.security_icon)
+        securityIcon?.setOnClickListener {
+            container.context.showSslDialog()
+        }
+        */
+
         with(container.context) {
             val isPinningSupported = components.webAppUseCases.isPinningSupported()
 
@@ -121,8 +129,8 @@ class BrowserToolbarView(
 
                 display.colors = display.colors.copy(
                     text = primaryTextColor,
-                    securityIconSecure = primaryTextColor,
-                    securityIconInsecure = primaryTextColor,
+                    siteInfoIconSecure = primaryTextColor,
+                    siteInfoIconInsecure = primaryTextColor,
                     menu = primaryTextColor,
                     hint = secondaryTextColor,
                     separator = separatorColor,

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
@@ -78,11 +78,7 @@ class BrowserToolbarView(
             true
         }
 
-        // TODO: add security_icon resource
-        val securityIcon = layout.findViewById<ImageView>(R.id.security_icon)
-        securityIcon?.setOnClickListener {
-            container.context.showSslDialog()
-        }
+        // TODO: add a handler for the ssl button.
 
 
         with(container.context) {

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
@@ -4,6 +4,7 @@ import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -12,6 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.cookiejarapps.android.smartcookieweb.R
 import com.cookiejarapps.android.smartcookieweb.ext.components
 import com.cookiejarapps.android.smartcookieweb.preferences.UserPreferences
+import com.cookiejarapps.android.smartcookieweb.ssl.showSslDialog
 import com.cookiejarapps.android.smartcookieweb.utils.ToolbarPopupWindow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.state.selector.selectedTab
@@ -19,7 +21,6 @@ import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.support.ktx.util.URLStringUtils.toDisplayUrl
-import mozilla.components.ui.tabcounter.TabCounterMenu
 import mozilla.components.ui.widgets.behavior.EngineViewScrollingBehavior
 import java.lang.ref.WeakReference
 import mozilla.components.ui.widgets.behavior.ViewPosition as MozacToolbarPosition
@@ -78,12 +79,11 @@ class BrowserToolbarView(
         }
 
         // TODO: add security_icon resource
-        /*
         val securityIcon = layout.findViewById<ImageView>(R.id.security_icon)
         securityIcon?.setOnClickListener {
             container.context.showSslDialog()
         }
-        */
+
 
         with(container.context) {
             val isPinningSupported = components.webAppUseCases.isPinningSupported()

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/BrowserToolbarView.kt
@@ -4,7 +4,6 @@ import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/components/toolbar/ToolbarIntegration.kt
@@ -107,8 +107,8 @@ class DefaultToolbarIntegration(
 
 
         toolbar.display.colors = toolbar.display.colors.copy(
-            securityIconInsecure = 0xFFd9534f.toInt(),
-            securityIconSecure = 0xFF5cb85c.toInt(),
+            siteInfoIconInsecure = 0xFFd9534f.toInt(),
+            siteInfoIconSecure = 0xFF5cb85c.toInt(),
             text = context.getColorFromAttr(android.R.attr.textColorPrimary),
             menu = context.getColorFromAttr(android.R.attr.textColorPrimary),
             separator = 0x1E15141a,

--- a/app/src/main/java/com/cookiejarapps/android/smartcookieweb/downloads/DownloadService.kt
+++ b/app/src/main/java/com/cookiejarapps/android/smartcookieweb/downloads/DownloadService.kt
@@ -4,9 +4,10 @@ import com.cookiejarapps.android.smartcookieweb.R
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import com.cookiejarapps.android.smartcookieweb.ext.components
+import mozilla.components.feature.downloads.FileSizeFormatter
 import mozilla.components.support.base.android.NotificationsDelegate
 
-class DownloadService: AbstractFetchDownloadService() {
+class DownloadService(override val fileSizeFormatter: FileSizeFormatter) : AbstractFetchDownloadService() {
     override val httpClient by lazy { components.client }
     override val store: BrowserStore by lazy { components.store }
     override val style: Style by lazy { Style(R.color.photonBlue40) }

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -4,5 +4,4 @@
     <item name="url_bar" type="id"/>
     <item name="browser_action" type="id"/>
     <item name="tabs_button" type="id"/>
-    <item name="security_icon" type="id" />
 </resources>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -4,4 +4,5 @@
     <item name="url_bar" type="id"/>
     <item name="browser_action" type="id"/>
     <item name="tabs_button" type="id"/>
+    <item name="security_icon" type="id" />
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = '2.1.20'
     repositories {
         maven {
             name "Mozilla"
@@ -10,9 +10,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.9.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.9"
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.9.0"
 
         classpath "org.mozilla.components:tooling-glean-gradle:95.0.5"
         // NOTE: Do not place your application dependencies here; they belong
@@ -21,7 +21,8 @@ buildscript {
 }
 
 plugins {
-    id("com.google.devtools.ksp") version "1.9.25-1.0.20" apply false
+    id("com.google.devtools.ksp") version "2.1.20-1.0.31" apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.1.0' apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.2'
+        classpath 'com.android.tools.build:gradle:8.10.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.9.0"
 


### PR DESCRIPTION
The ssl button does not handle click since mozac 138 removed the mozilla.components.browser.toolbar.display.SiteSecurityAction class. Not critical but it needs to be fixed later. Also, on the extension install view the buttons are a bit misplaced. But in this case i'm not sure why it is like that. I will also need to clean some bits.